### PR TITLE
Use already exsting file

### DIFF
--- a/@app/db/.gmrc
+++ b/@app/db/.gmrc
@@ -68,7 +68,7 @@
     "!afterReset.sql",
     {
       "_": "command",
-      "command": "cross-env-shell \"DATABASE_URL=\\\"$GM_DBURL\\\" yarn workspace @app/worker install-db-schema\""
+      "command": "node scripts/after-reset.js"
     }
   ],
 


### PR DESCRIPTION
Hi @MegaCookie I have tested your PR with windows-support to graphile/starter and I have found here problem.
You have already write "after-reset.js" script but you don't use it and in graphile_starter_test db we don't have graphile_worker.jobs table.
With my fix everything works as expected

btw. thanks for making windows-support PR